### PR TITLE
Use MOV and SYSCALL templates in acceptloop_ipv4 and mprotect_all

### DIFF
--- a/pwnlib/shellcraft/templates/i386/linux/acceptloop_ipv4.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/acceptloop_ipv4.asm
@@ -19,23 +19,22 @@ ${acceptloop}:
         /*  Socket file descriptor is placed in EBP */
 
         /*  sock = socket(AF_INET, SOCK_STREAM, 0) */
-        xor edx, edx
-        push edx                            /*  IPPROTO_IP (= 0) */
-        push SYS_socketcall_socket          /*  SOCK_STREAM */
-        push AF_INET
+        ${i386.linux.push(0)}
+        ${i386.linux.push('SOCK_STREAM')}
+        ${i386.linux.push('AF_INET')}
         ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_socket', 'esp')}
 
         ${i386.linux.mov('esi', 'eax')}      /* keep socket fd */
 
         /*  bind(sock, &addr, sizeof addr); // sizeof addr == 0x10 */
-        push edx
+        ${i386.linux.push(0)}
         /* ${htons(port)} == htons(${port}) */
         ${i386.linux.push('AF_INET | (%d << 16)' % htons(port))}
         ${i386.linux.mov('ecx', 'esp')}
-        push 0x10               /* sizeof addr */
-        push ecx                /* &addr */
-        push eax                /* sock */
-        ${i386.linux.mov('ecx', 'esp')}
+
+        ${i386.linux.push(0x10)}    /* sizeof addr */
+        ${i386.linux.push('ecx')}   /* &addr */
+        ${i386.linux.push('eax')}   /* sock */
         ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_bind', 'esp')}
 
         /*  listen(sock, whatever) */
@@ -44,8 +43,8 @@ ${acceptloop}:
 
 ${looplabel}:
         /*  accept(sock, NULL, NULL) */
-        push edx
-        push esi                /*  sock */
+        ${i386.linux.push(0x0)}
+        ${i386.linux.push('esi')} /* sock */
         ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_accept', 'esp')}
 
         ${i386.linux.mov('ebp', 'eax')}      /* keep in-comming socket fd */

--- a/pwnlib/shellcraft/templates/i386/linux/acceptloop_ipv4.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/acceptloop_ipv4.asm
@@ -1,63 +1,64 @@
 <%
-  from pwnlib.shellcraft import common
-  from pwnlib.shellcraft import i386
-  from socket import htons
+    from pwnlib.shellcraft import common
+    from pwnlib.shellcraft import i386
+    from socket import htons
 %>
 <%page args="port"/>
 <%docstring>
-    Args: port
+    Args:
+        port(int): the listening port
     Waits for a connection.  Leaves socket in EBP.
     ipv4 only
 </%docstring>
 <%
-  acceptloop = common.label("acceptloop")
-  looplabel = common.label("loop")
+    acceptloop = common.label("acceptloop")
+    looplabel = common.label("loop")
 %>
 
 ${acceptloop}:
-        /*  Listens for and accepts a connection on ${int(port)}d forever */
-        /*  Socket file descriptor is placed in EBP */
+    /*  Listens for and accepts a connection on ${int(port)}d forever */
+    /*  Socket file descriptor is placed in EBP */
 
-        /*  sock = socket(AF_INET, SOCK_STREAM, 0) */
-        ${i386.linux.push(0)}
-        ${i386.linux.push('SOCK_STREAM')}
-        ${i386.linux.push('AF_INET')}
-        ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_socket', 'esp')}
+    /*  sock = socket(AF_INET, SOCK_STREAM, 0) */
+    ${i386.linux.push(0)}
+    ${i386.linux.push('SOCK_STREAM')}
+    ${i386.linux.push('AF_INET')}
+    ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_socket', 'esp')}
 
-        ${i386.linux.mov('esi', 'eax')}      /* keep socket fd */
+    ${i386.linux.mov('esi', 'eax')}      /* keep socket fd */
 
-        /*  bind(sock, &addr, sizeof addr); // sizeof addr == 0x10 */
-        ${i386.linux.push(0)}
-        /* ${htons(port)} == htons(${port}) */
-        ${i386.linux.push('AF_INET | (%d << 16)' % htons(port))}
-        ${i386.linux.mov('ecx', 'esp')}
+    /*  bind(sock, &addr, sizeof addr); // sizeof addr == 0x10 */
+    ${i386.linux.push(0)}
+    /* ${htons(port)} == htons(${port}) */
+    ${i386.linux.push('AF_INET | (%d << 16)' % htons(port))}
+    ${i386.linux.mov('ecx', 'esp')}
 
-        ${i386.linux.push(0x10)}    /* sizeof addr */
-        ${i386.linux.push('ecx')}   /* &addr */
-        ${i386.linux.push('eax')}   /* sock */
-        ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_bind', 'esp')}
+    ${i386.linux.push(0x10)}    /* sizeof addr */
+    ${i386.linux.push('ecx')}   /* &addr */
+    ${i386.linux.push('eax')}   /* sock */
+    ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_bind', 'esp')}
 
-        /*  listen(sock, whatever) */
-        ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_listen')}
+    /*  listen(sock, whatever) */
+    ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_listen')}
 
 
 ${looplabel}:
-        /*  accept(sock, NULL, NULL) */
-        ${i386.linux.push(0x0)}
-        ${i386.linux.push('esi')} /* sock */
-        ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_accept', 'esp')}
+    /*  accept(sock, NULL, NULL) */
+    ${i386.linux.push(0x0)}
+    ${i386.linux.push('esi')} /* sock */
+    ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_accept', 'esp')}
 
-        ${i386.linux.mov('ebp', 'eax')}      /* keep in-comming socket fd */
+    ${i386.linux.mov('ebp', 'eax')}      /* keep in-comming socket fd */
 
-        ${i386.linux.syscall('SYS_fork')}
-        xchg eax, edi
+    ${i386.linux.syscall('SYS_fork')}
+    xchg eax, edi
 
-        test edi, edi
-        ${i386.linux.mov('ebx', 'ebp')}
-        cmovz ebx, esi /*  on child we close the server sock instead */
+    test edi, edi
+    ${i386.linux.mov('ebx', 'ebp')}
+    cmovz ebx, esi /*  on child we close the server sock instead */
 
-        /*  close(sock) */
-        ${i386.linux.syscall('SYS_close', 'ebx')}
+    /*  close(sock) */
+    ${i386.linux.syscall('SYS_close', 'ebx')}
 
-        test edi, edi
-        jnz ${looplabel}
+    test edi, edi
+    jnz ${looplabel}

--- a/pwnlib/shellcraft/templates/i386/linux/acceptloop_ipv4.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/acceptloop_ipv4.asm
@@ -19,51 +19,42 @@ ${acceptloop}:
         /*  Socket file descriptor is placed in EBP */
 
         /*  sock = socket(AF_INET, SOCK_STREAM, 0) */
-        ${i386.linux.mov('eax', 'SYS_socketcall')}
-        ${i386.linux.mov('ebx', 'SYS_socketcall_socket')}
-        cdq                     /*  clear EDX */
-        push edx                /*  IPPROTO_IP (= 0) */
-        push ebx                /*  SOCK_STREAM */
+        xor edx, edx
+        push edx                            /*  IPPROTO_IP (= 0) */
+        push SYS_socketcall_socket          /*  SOCK_STREAM */
         push AF_INET
-        ${i386.linux.syscall('eax', 'ebx', 'esp')}
+        ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_socket', 'esp')}
+
+        ${i386.linux.mov('esi', 'eax')}      /* keep socket fd */
 
         /*  bind(sock, &addr, sizeof addr); // sizeof addr == 0x10 */
         push edx
         /* ${htons(port)} == htons(${port}) */
         ${i386.linux.push('AF_INET | (%d << 16)' % htons(port))}
-        mov ecx, esp
-        push 0x10
-        push ecx
-        push eax
-        mov ecx, esp
-        mov esi, eax
-        inc ebx                 /*  EBX = bind (= 2) */
-        mov al, SYS_socketcall
-        int 0x80
+        ${i386.linux.mov('ecx', 'esp')}
+        push 0x10               /* sizeof addr */
+        push ecx                /* &addr */
+        push eax                /* sock */
+        ${i386.linux.mov('ecx', 'esp')}
+        ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_bind', 'esp')}
 
         /*  listen(sock, whatever) */
-        mov al, SYS_socketcall
-        mov bl, SYS_socketcall_listen
-        int 0x80
+        ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_listen')}
 
 
 ${looplabel}:
         /*  accept(sock, NULL, NULL) */
         push edx
         push esi                /*  sock */
-        mov ecx, esp
-        mov al, SYS_socketcall
-        mov bl, SYS_socketcall_accept
-        int 0x80
+        ${i386.linux.syscall('SYS_socketcall', 'SYS_socketcall_accept', 'esp')}
 
-        mov ebp, eax
+        ${i386.linux.mov('ebp', 'eax')}      /* keep in-comming socket fd */
 
-        mov al, SYS_fork
-        int 0x80
+        ${i386.linux.syscall('SYS_fork')}
         xchg eax, edi
 
         test edi, edi
-        mov ebx, ebp
+        ${i386.linux.mov('ebx', 'ebp')}
         cmovz ebx, esi /*  on child we close the server sock instead */
 
         /*  close(sock) */

--- a/pwnlib/shellcraft/templates/i386/linux/mprotect_all.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/mprotect_all.asm
@@ -1,4 +1,7 @@
-<% from pwnlib.shellcraft import common %>
+<%
+  from pwnlib.shellcraft import common
+  from pwnlib.shellcraft import i386
+%>
 <%page args="clear_ebx = True, fix_null = False"/>
 <%docstring>Calls mprotect(page, 4096, PROT_READ | PROT_WRITE | PROT_EXEC) for every page.
 
@@ -17,12 +20,7 @@ Args:
     xor ecx, ecx
 %endif
 ${label}:
-    push PROT_READ | PROT_WRITE | PROT_EXEC
-    pop edx
-    push SYS_mprotect
-    pop eax
-    int 0x80
-    xor ecx, ecx
-    mov ch, 0x10
+    ${i386.linux.syscall('SYS_mprotect', 'ebx', 'ecx', 'PROT_READ | PROT_WRITE | PROT_EXEC')}
+    ${i386.linux.mov('ecx', 0x1000)}
     add ebx, ecx
     jnz ${label}

--- a/pwnlib/shellcraft/templates/i386/linux/mprotect_all.asm
+++ b/pwnlib/shellcraft/templates/i386/linux/mprotect_all.asm
@@ -1,15 +1,16 @@
 <%
-  from pwnlib.shellcraft import common
-  from pwnlib.shellcraft import i386
+    from pwnlib.shellcraft import common
+    from pwnlib.shellcraft import i386
 %>
 <%page args="clear_ebx = True, fix_null = False"/>
-<%docstring>Calls mprotect(page, 4096, PROT_READ | PROT_WRITE | PROT_EXEC) for every page.
+<%docstring>
+    Calls mprotect(page, 4096, PROT_READ | PROT_WRITE | PROT_EXEC) for every page.
 
-It takes around 0.3 seconds on my box, but your milage may vary.
+    It takes around 0.3 seconds on my box, but your milage may vary.
 
-Args:
-  clear_ebx(bool): If this is set to False, then the shellcode will assume that ebx has already been zeroed.
-  fix_null(bool): If this is set to True, then the NULL-page will also be mprotected at the cost of slightly larger shellcode
+    Args:
+        clear_ebx(bool): If this is set to False, then the shellcode will assume that ebx has already been zeroed.
+        fix_null(bool): If this is set to True, then the NULL-page will also be mprotected at the cost of slightly larger shellcode
 </%docstring>
 <% label = common.label("mprotect_loop") %>
 


### PR DESCRIPTION
I have finished this job and tested the behavior under `strace` and `gdb`.

There some changes in this commit.
1. I rewrote the beginning part of `acceptloop_ipv4` for readability.
2. Using the syscall template will increase the payload length. (In `acceptloop_ipv4`: 84 -> 94 bytes)
The origin code use some knowledge (reuse the register) to reduce the code length.