### PR TITLE
Initial set of commits integrating SROP with ROP

### DIFF
--- a/docs/source/rop.rst
+++ b/docs/source/rop.rst
@@ -2,7 +2,9 @@
 
    from pwnlib.elf import *
    from pwnlib.rop import *
-   from pwnlib.util.misc import which
+   from pwnlib.context import *
+   from pwnlib.util.misc import which, write
+   from pwnlib.asm import make_elf, asm
 
 :mod:`pwnlib.rop` --- Return Oriented Programming
 =================================================

--- a/pwnlib/srop.py
+++ b/pwnlib/srop.py
@@ -98,6 +98,12 @@ class SigreturnFrame(object):
         value = pack(val)
         self.frame[index] = value
 
+    def get_stackpointer_index(self):
+        if self.arch == "i386":
+            return _registers_32.index("esp")
+        elif self.arch == "amd64":
+            return _registers_64.index("rsp")
+
     def get_frame(self):
         frame_contents = ''.join(self.frame)
         if self.arch == "i386":


### PR DESCRIPTION
This is an initial working commit that does the following
1. Integrates SROP with ROP
2. Modifies dump to print out SROP specific register information

For (crude)testing the script here was used: https://gist.github.com/eQu1NoX/5ba246ecb9b0f238252d
Output of the script is also attached in the above gist.

The major changes made to make this work are as follows.
~~1. _build_x86 used to add a pivot regardless of the gadget used. This caused a problem when I added in a gadget such as "pop eax; ret" as there would be a pivot added in for that too. So, a new function "_needs_pivoting" tries to determine if pivoting is required(basically if its a "pop" dont do pivoting).~~
2. A "self.srop_start_index" value is introduced, that is an index into the output returned from self.build. This indicates where the srop chain begins so that dump can print the srop register information accordingly.
~~3. Some parts of it need error handling/cleaning up and making it easier to add in more architectures(like the place where I find the syscall instruction); I'll make those changes soon.~~