### PR TITLE
import pwnlib after sys.path's change

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,12 +15,12 @@ import os
 import subprocess
 import sys
 
-import pwnlib
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../..'))
+
+import pwnlib
 
 # -- General configuration -----------------------------------------------------
 


### PR DESCRIPTION
In my case, sphinx was importing code from /usr/lib. After investigation, we need to import pwnlib after the sys.path's change.

Before
```
[autodoc] => <module 'pwnlib.testexample' from '/usr/lib/python2.7/site-packages/pwnlib/testexample.pyc'>
```

After
```
[autodoc] => <module 'pwnlib.testexample' from '/home/tlk/Tools/binjitsu/pwnlib/testexample.py'>
```