### PR TITLE
Add in support for mips, mipsel + doctests

### DIFF
--- a/pwnlib/rop/rop.py
+++ b/pwnlib/rop/rop.py
@@ -547,7 +547,8 @@ class ROP(object):
                 if slot.sp in (0, None) and self.base:
                     slot.sp = stack.next + len(slot)
 
-                for register in slot.registers:
+                registers = [slot.registers[i] for i in sorted(slot.registers.keys())]
+                for register in registers:
                     value       = slot[register]
                     description = self.describe(value)
                     if description:


### PR DESCRIPTION
- Add support for MIPS and MIPSel
- Change format to offset:register in srop.py
- Correct doctests in srop.py
- Change usage in rop.py
- get_frame removed