### PR TITLE
Import pwnlib.util.safeeval in constgrep

### DIFF
--- a/pwnlib/commandline/constgrep.py
+++ b/pwnlib/commandline/constgrep.py
@@ -7,6 +7,7 @@ import re
 from pwnlib.context import context
 from pwnlib import constants
 from pwnlib.asm import cpp
+from pwnlib.util import safeeval
 
 from . import common
 


### PR DESCRIPTION
On my install of binjitsu I couldn't use the command tool 'constgrep' with both a regex and a constant. A missing import was the cause, this PR fixes that.